### PR TITLE
upgrade tap dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "htmlparser": "^1.7.7"
   },
   "devDependencies": {
-    "tap": "^1.4.0"
+    "tap": "^14.10.7"
   }
 }


### PR DESCRIPTION
**Why**
`npm audit` is warning us of 13 security vulnerabilities (2 low, 6 moderate, 5 high) that are related to `tap`, which is the test dependency. See [CH ticket](https://app.clubhouse.io/guru/story/29269/upgrade-slackify-html-test-dependency-version-to-fix-security-vulnerabilities) for details.

**What**
Upgrading `tap` to the recommended version (^14.10.7) to fix all 13 security vulnerabilities. The test results when running `npm test` now include a nice summary too!

```
> tap tests.js

 PASS  tests.js 43 OK 76.012ms

                         
  🌈 SUMMARY RESULTS 🌈  
                         

Suites:   1 passed, 1 of 1 completed
Asserts:  43 passed, of 43
Time:     1s
------------------|----------|----------|----------|----------|-------------------|
File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------|----------|----------|----------|----------|-------------------|
All files         |    92.57 |    83.33 |      100 |    92.49 |                   |
 slackify-html.js |    92.57 |    83.33 |      100 |    92.49 |... 25,230,237,270 |
------------------|----------|----------|----------|----------|-------------------|
```